### PR TITLE
objc_super is defined in objc/message.h

### DIFF
--- a/gst-objc-ext.h
+++ b/gst-objc-ext.h
@@ -4,7 +4,9 @@
 #import "gst-string.h"
 #import "gst-array.h"
 #import "objc-proxy.h"
-#ifndef GNU_RUNTIME
+#ifdef GNU_RUNTIME
+#import <objc/message.h>
+#else
 #import <objc/objc-runtime.h>
 #endif
 


### PR DESCRIPTION
I'm using libobjc from gcc, version 6.3.1 (specifically fedora core 25: gcc (GCC) 6.3.1 20161221 (Red Hat 6.3.1-1)). To build gst-objc I needed to include the file `objc/message.h`.